### PR TITLE
Added support for every keyboard with macros

### DIFF
--- a/src/components/MacrosMenu/MacrosMenu.jsx
+++ b/src/components/MacrosMenu/MacrosMenu.jsx
@@ -64,9 +64,14 @@ function MacrosMenu({ visibility, fullVisibility }) {
     const handleKeypress = e => {
       if (!allowedModes.get('Chevron').has(mode)) return
 
+      // If the shift key is pressed
       if (e.shiftKey) {
-        for (const macro of pinnedMacros) {
-          if (e.code === macro.key) {
+
+        // For every macro if not null
+        for (const macro of pinnedMacros.filter(m => m.key)) {
+          // Support of all keyboards by using the key instead of the code
+          // Supporting "keyX" or "X" in the config + case insensitive
+          if (e.key.toUpperCase() === macro.key.toUpperCase() || ("key" + e.key).toUpperCase() === macro.key.toUpperCase()) {
             activateCard(macro)
             break
           }

--- a/src/components/MacrosMenu/MacrosMenu.jsx
+++ b/src/components/MacrosMenu/MacrosMenu.jsx
@@ -64,9 +64,14 @@ function MacrosMenu({ visibility, fullVisibility }) {
     const handleKeypress = e => {
       if (!allowedModes.get('Chevron').has(mode)) return
 
+      // If the shift key is pressed
       if (e.shiftKey) {
-        for (const macro of pinnedMacros) {
-          if (e.code === macro.key) {
+
+        // For every macro if not null
+        for (const macro of pinnedMacros.filter(m => m.key)) {
+          // Support of all keyboards by using the key instead of the code
+          // Supporting "keyX" or "X" in the config + case insensitive
+          if (e.key.toUpperCase() === macro.key || ("key" + e.key).toUpperCase() === macro.key.toUpperCase()) {
             activateCard(macro)
             break
           }

--- a/src/components/MacrosMenu/MacrosMenu.jsx
+++ b/src/components/MacrosMenu/MacrosMenu.jsx
@@ -71,7 +71,7 @@ function MacrosMenu({ visibility, fullVisibility }) {
         for (const macro of pinnedMacros.filter(m => m.key)) {
           // Support of all keyboards by using the key instead of the code
           // Supporting "keyX" or "X" in the config + case insensitive
-          if (e.key.toUpperCase() === macro.key || ("key" + e.key).toUpperCase() === macro.key.toUpperCase()) {
+          if (e.key.toUpperCase() === macro.key.toUpperCase() || ("key" + e.key).toUpperCase() === macro.key.toUpperCase()) {
             activateCard(macro)
             break
           }


### PR DESCRIPTION
 ### Added support for every keyboard with macros by using `e.key` instead of `e.code`
 - Why ?
> Using `e.code` returns the QWERTY key. For instance, pressing "Z" on a AZERTY keyboard would return "W" 

<br>

 ### Added support for a single char in `key:` option in `config.js`
- Why ?
> Due to this change, `e.code` returns the value of the key pressed (`e`, `a`, ...) instead of `KeyE`, `KeyA`, ....
> Chevron will keep supporting of `KeyX` in order to avoid breaking updates

<br>

 ### `key:` option in `config.js` is now case-insensitive
- Why ?
> Why not ?